### PR TITLE
Get objects from APIObjects and get an object from id and resource type added

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,9 +1,18 @@
-disabled_rules:
-  - identifier_name
-  - cyclomatic_complexity 
-  - type_body_length
-  - function_body_length
-  - line_length
+# disabled_rules:
+#  - identifier_name
+#  - cyclomatic_complexity
+#  - function_body_length
+whitelist_rules:
+  - trailing_whitespace
+  - colon
+  - vertical_whitespace
+  - shorthand_operator
+  - redundant_optional_initialization
+  - for_where
+  - trailing_newline
+  - unused_optional_binding
+  - comma
+  - opening_brace
 excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - ParsecTests
+  
 line_length: 200

--- a/Parsec.podspec
+++ b/Parsec.podspec
@@ -1,19 +1,19 @@
 Pod::Spec.new do |s|
 s.name             = "Parsec"
-s.version          = "1.0.2"
+s.version          = "1.1.0"
 s.summary          = "Modular JSON API to Core Data parser and validator"
 s.description      = <<-DESC
-**Parsec** eases the task of getting a `JSON API` response into Core Data.
+**Parsec** eases the task of getting `JSON API` documents into Core Data.
 DESC
 s.homepage         = 'https://github.com/InQBarna/Parsec'
 s.license          = 'MIT'
-s.author           = { "David Romacho" => "david.romacho@inqbarna.com" }
-s.source           = { :git => "https://github.com/InQBarna/Parsec/Parsec.git" }
+s.author           = { 'David Romacho' => 'david.romacho@inqbarna.com', 'Santiago Becerra' => 'santiago.becerra@inqbarna.com' }
+s.source           = { :git => "https://github.com/InQBarna/Parsec/Parsec.git", :tag => 'v1.1.0' }
 
 s.ios.deployment_target = '10.0'
 s.requires_arc = true
 s.source_files = 'Source/**/*'
-s.swift_version = '4.2'
+s.swift_version = '5.0'
 
 s.frameworks = 'Foundation', 'CoreData'
 end

--- a/Parsec.xcodeproj/project.pbxproj
+++ b/Parsec.xcodeproj/project.pbxproj
@@ -326,11 +326,11 @@
 				TargetAttributes = {
 					63F8FD1A21135A0D000A4791 = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1130;
 					};
 					63F8FD2321135A0D000A4791 = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1130;
 					};
 				};
 			};
@@ -631,7 +631,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -656,7 +656,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.inqbarna.Parsec;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -674,7 +674,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.inqbarna.ParsecTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -692,7 +692,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.inqbarna.ParsecTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Parsec.xcodeproj/project.pbxproj
+++ b/Parsec.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		63970D6021157AB400438159 /* OpenAPISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63970D5F21157AB400438159 /* OpenAPISpec.swift */; };
 		63970D6121157AB400438159 /* OpenAPISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63970D5F21157AB400438159 /* OpenAPISpec.swift */; };
 		63970D6421157ABD00438159 /* OpenApiSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63970D6221157ABD00438159 /* OpenApiSpecTests.swift */; };
+		639D8CBA243E223F0080FA11 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639D8CB9243E223F0080FA11 /* LoggerTests.swift */; };
 		63F8FD2521135A0D000A4791 /* Parsec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63F8FD1B21135A0D000A4791 /* Parsec.framework */; };
 		63F8FD2A21135A0D000A4791 /* ParsecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8FD2921135A0D000A4791 /* ParsecTests.swift */; };
 		63F8FD3821135AD8000A4791 /* JSONAPIParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8FD3721135AD8000A4791 /* JSONAPIParser.swift */; };
@@ -129,6 +130,7 @@
 		63970D5D2114A8B700438159 /* EntitySerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitySerializerTests.swift; sourceTree = "<group>"; };
 		63970D5F21157AB400438159 /* OpenAPISpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenAPISpec.swift; sourceTree = "<group>"; };
 		63970D6221157ABD00438159 /* OpenApiSpecTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenApiSpecTests.swift; sourceTree = "<group>"; };
+		639D8CB9243E223F0080FA11 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		63F8FD1B21135A0D000A4791 /* Parsec.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Parsec.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63F8FD1F21135A0D000A4791 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63F8FD2421135A0D000A4791 /* ParsecTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParsecTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -247,6 +249,7 @@
 				634098B42215A9790088F696 /* DoubleSerializerTests.swift */,
 				634098B62215A9D90088F696 /* FloatSerializerTests.swift */,
 				634098B82215AA360088F696 /* BooleanSerializerTests.swift */,
+				639D8CB9243E223F0080FA11 /* LoggerTests.swift */,
 			);
 			path = ParsecTests;
 			sourceTree = "<group>";
@@ -471,6 +474,7 @@
 				634098AF22158A1A0088F696 /* Int32SerializerTests.swift in Sources */,
 				6340989822157F0A0088F696 /* UnixTimestampSerializer.swift in Sources */,
 				634098A122157F0A0088F696 /* BooleanSerializer.swift in Sources */,
+				639D8CBA243E223F0080FA11 /* LoggerTests.swift in Sources */,
 				63F8FD3C21135DAD000A4791 /* JSONAPIParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Parsec.xcodeproj/project.pbxproj
+++ b/Parsec.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		63970D6121157AB400438159 /* OpenAPISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63970D5F21157AB400438159 /* OpenAPISpec.swift */; };
 		63970D6421157ABD00438159 /* OpenApiSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63970D6221157ABD00438159 /* OpenApiSpecTests.swift */; };
 		639D8CBA243E223F0080FA11 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639D8CB9243E223F0080FA11 /* LoggerTests.swift */; };
+		639D8CBC243E2B540080FA11 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639D8CBB243E2B540080FA11 /* Logger.swift */; };
+		639D8CBD243E2BD30080FA11 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639D8CBB243E2B540080FA11 /* Logger.swift */; };
 		63F8FD2521135A0D000A4791 /* Parsec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63F8FD1B21135A0D000A4791 /* Parsec.framework */; };
 		63F8FD2A21135A0D000A4791 /* ParsecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8FD2921135A0D000A4791 /* ParsecTests.swift */; };
 		63F8FD3821135AD8000A4791 /* JSONAPIParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8FD3721135AD8000A4791 /* JSONAPIParser.swift */; };
@@ -131,6 +133,7 @@
 		63970D5F21157AB400438159 /* OpenAPISpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenAPISpec.swift; sourceTree = "<group>"; };
 		63970D6221157ABD00438159 /* OpenApiSpecTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenApiSpecTests.swift; sourceTree = "<group>"; };
 		639D8CB9243E223F0080FA11 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
+		639D8CBB243E2B540080FA11 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		63F8FD1B21135A0D000A4791 /* Parsec.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Parsec.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63F8FD1F21135A0D000A4791 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63F8FD2421135A0D000A4791 /* ParsecTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParsecTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -194,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				63F8FD4121135F0E000A4791 /* Parsec.swift */,
+				639D8CBB243E2B540080FA11 /* Logger.swift */,
 				63970D5F21157AB400438159 /* OpenAPISpec.swift */,
 				63970D552114A3B900438159 /* EntitySerializer.swift */,
 				63970D532114A33C00438159 /* AttributeSerializer.swift */,
@@ -402,6 +406,7 @@
 				6340989222157D6F0088F696 /* BooleanSerializer.swift in Sources */,
 				6340987A22157BDE0088F696 /* StringSerializer.swift in Sources */,
 				6340987E22157C260088F696 /* Base64DataSerializer.swift in Sources */,
+				639D8CBC243E2B540080FA11 /* Logger.swift in Sources */,
 				6340988622157CB80088F696 /* Int16Serializer.swift in Sources */,
 				63970D4D21149E9A00438159 /* ContextUpdater.swift in Sources */,
 				6340988422157C9A0088F696 /* URISerializer.swift in Sources */,
@@ -460,6 +465,7 @@
 				631F1946211487DC000678B6 /* AttributeDeserializationTests.swift in Sources */,
 				63970D5E2114A8B700438159 /* EntitySerializerTests.swift in Sources */,
 				6340989622157F0A0088F696 /* ISO8601DateSerializer.swift in Sources */,
+				639D8CBD243E2BD30080FA11 /* Logger.swift in Sources */,
 				63F8FD2A21135A0D000A4791 /* ParsecTests.swift in Sources */,
 				634098B32215A8600088F696 /* DecimalSerializerTests.swift in Sources */,
 				634098A5221582340088F696 /* Base64DataSerializerTests.swift in Sources */,

--- a/ParsecTests/EntitySerializerTests.swift
+++ b/ParsecTests/EntitySerializerTests.swift
@@ -28,7 +28,7 @@ import CoreData
 
 class EntitySerializerTests: XCTestCase {
 
-    func entitySerializerTest() {
+    func testEntitySerializer() {
 
         let attributes: [String: APIAttribute] = ["a_boolean": try! APIAttribute(value: true),
                                           "a_date": try! APIAttribute(value: "2018-01-23T03:06:46Z"),

--- a/ParsecTests/LoggerTests.swift
+++ b/ParsecTests/LoggerTests.swift
@@ -1,0 +1,97 @@
+//
+// LoggerTests.swift
+//
+// Copyright (c) 2020 InQBarna Kenkyuu Jo (http://inqbarna.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import XCTest
+import CoreData
+@testable import Parsec
+
+class LoggerTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testLogger() {
+
+        let attributes: [String: APIAttribute] = ["a_boolean": try! APIAttribute(value: true),
+                                                  "a_date": try! APIAttribute(value: "2018-01-23T03:06:46Z"),
+                                                  "a_decimal": try! APIAttribute(value: 1.65),
+                                                  "a_double": try! APIAttribute(value: 2.323),
+                                                  "a_float": try! APIAttribute(value: 3.456),
+                                                  "an_integer16": try! APIAttribute(value: 1),
+                                                  "an_integer32": try! APIAttribute(value: 2),
+                                                  "an_integer64": try! APIAttribute(value: 3),
+                                                  "a_string": try! APIAttribute(value: "lorem ipsum"),
+                                                  "unknown_field": try! APIAttribute(value: "lorem ipsum"),
+                                                  "an_uuid": try! APIAttribute(value: "b8c01b3c-525a-4e33-ab02-6d8cdbd1e427"),
+                                                  "an_uri": try! APIAttribute(value: "https://jsonapi.org")]
+        let relationships: [String: APIRelationship] = ["to_one": APIRelationship(type: "entity2_b", value: .toOne(id: "1")),
+                                                        "to_many": APIRelationship(type: "entity2_b", value: .toMany(ids: ["1", "2", "3"]))]
+
+        let object = APIObject(type: "entity2_a", id: "1", attributes: attributes, relationships: relationships)
+
+        let context = TestTools.shared.createContext(with: "Test_2_optionals")
+        let model = context.persistentStoreCoordinator!.managedObjectModel
+        XCTAssert(context.persistentStoreCoordinator?.managedObjectModel != nil)
+
+        do {
+            let spy = SpyLogger(logMissing: true, logUnknown: true)
+            let parsec = try Parsec(model: model)
+            parsec.logger = spy
+            let entity = parsec.entitiesByName["Entity2A"]!
+            let objectChanges = try entity.deserialize(object)
+
+            XCTAssert(objectChanges.entitySerializer == entity)
+            XCTAssert(objectChanges.id is String)
+            XCTAssert(objectChanges.id as! String == "1")
+            XCTAssert(spy.lastLog != nil)
+            XCTAssert(spy.logCount == 3)
+        } catch {
+            XCTAssert(false)
+        }
+    }
+}
+
+private class SpyLogger: Logger {
+    let logUnknown: Bool
+    let logMissing: Bool
+
+    var lastLog: String?
+    var logCount = 0
+
+    init(logMissing: Bool, logUnknown: Bool) {
+        self.logMissing = logMissing
+        self.logUnknown = logUnknown
+    }
+
+    func log(_ level: LogLevel, _ text: @autoclosure () -> String) {
+        let lastLog = text()
+        logCount += 1
+        self.lastLog = lastLog
+    }
+}

--- a/ParsecTests/ParsecTests.swift
+++ b/ParsecTests/ParsecTests.swift
@@ -73,7 +73,7 @@ class ParsecTests: XCTestCase {
         let sut = try! Parsec(model: model)
         XCTAssertThrowsError(try sut.managedObject(with: "1", remoteName: "UnknownClass", context: context))
     }
-    
+
     func testManagedObjectsWithSuccess() {
         let context = TestTools.shared.createContext(with: "Test_2_optionals")
         let model = context.persistentStoreCoordinator!.managedObjectModel
@@ -86,7 +86,7 @@ class ParsecTests: XCTestCase {
 
         let sut = try! Parsec(model: model)
         let result = try! sut.managedObjectsFrom(apiObjects, context: context)
-        let resultIds = result.compactMap( {$0.value(forKey: "id") as? String} )
+        let resultIds = result.compactMap({$0.value(forKey: "id") as? String} )
         XCTAssert(resultIds == ids)
     }
 

--- a/Source/EntitySerializer.swift
+++ b/Source/EntitySerializer.swift
@@ -188,16 +188,34 @@ class EntitySerializer: NSObject {
 
             if let value = object.attributes[attribute.remoteName] {
                 validatedAttributes[name] = try attribute.deserialize(value)
+            } else {
+                if
+                    let logger = parsec?.logger,
+                    logger.logMissing
+                {
+                    logger.log(.warning, "Attribute '\(self.name).\(name)' not found in document while deserializing APIObject")
+                }
             }
         }
+
+        reportUnkownAttributes(object)
 
         var validatedRelationships: [String: RelationshipData] = [:]
 
         for (name, relationship) in self.relationshipsByName {
             if let rel = object.relationships[relationship.remoteName] {
                 validatedRelationships[name] = try relationship.deserialize(rel)
+            } else {
+                if
+                    let logger = parsec?.logger,
+                    logger.logMissing
+                {
+                    logger.log(.warning, "Relationship '\(self.name).\(name)' not found while deserializing APIObject")
+                }
             }
         }
+
+        reportUnkownRelationships(object)
 
         return ObjectData(id: object.id,
                           entitySerializer: self,
@@ -205,4 +223,39 @@ class EntitySerializer: NSObject {
                           relationships: validatedRelationships)
     }
 
+    private func reportUnkownAttributes(_ object: APIObject) {
+        guard
+            let logger = parsec?.logger,
+            logger.logUnknown
+        else {
+            return
+        }
+
+        let knownAttributes = Set(attributesByName.values.map({ (serializer) -> String in
+            return serializer.remoteName
+        }))
+        let objectAttributes = Set(object.attributes.keys)
+        let unknownAttributes = objectAttributes.subtracting(knownAttributes)
+        for name in unknownAttributes {
+            logger.log(.warning, "Unknown attribute '\(name)' found in document while deserializing entity '\(self.name)'")
+        }
+    }
+
+    private func reportUnkownRelationships(_ object: APIObject) {
+        guard
+            let logger = parsec?.logger,
+            logger.logUnknown
+        else {
+            return
+        }
+
+        let knownRelationships = Set(relationshipsByName.values.map({ (serializer) -> String in
+            return serializer.remoteName
+        }))
+        let objectRelationships = Set(object.relationships.keys)
+        let unknownRelationships = objectRelationships.subtracting(knownRelationships)
+        for name in unknownRelationships {
+            logger.log(.warning, "Unknown relationship '\(name)' found in document while deserializing entity '\(self.name)'")
+        }
+    }
 }

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -1,0 +1,39 @@
+//
+// Logger.swift
+//
+// Copyright (c) 2018 InQBarna Kenkyuu Jo (http://inqbarna.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import Foundation
+
+public enum LogLevel: Int {
+    case error
+    case warning
+    case info
+    case debug
+    case verbose
+}
+
+public protocol Logger {
+    func log(_ level: LogLevel, _ text: @autoclosure () -> String)
+    var logUnknown: Bool {get}
+    var logMissing: Bool {get}
+}

--- a/Source/Parsec.swift
+++ b/Source/Parsec.swift
@@ -253,6 +253,18 @@ public struct APIRelationship {
     }
 }
 
+public enum LogLevel: Int {
+    case error
+    case warning
+    case info
+    case debug
+    case verbose
+}
+
+public protocol Logger {
+    func log(_ level: LogLevel,_ text: String)
+}
+
 /// *Parsec*
 public class Parsec {
 
@@ -262,6 +274,7 @@ public class Parsec {
     public let defaultDateSerializer: Serializer
     public let defaultDataSerializer: Serializer
     public let defaultIdNames: [String]
+    public var logger: Logger?
 
     private(set) var entitiesByName: [String: EntitySerializer]
     private(set) var entitiesByType: [String: EntitySerializer]

--- a/Source/Parsec.swift
+++ b/Source/Parsec.swift
@@ -366,52 +366,47 @@ public class Parsec {
     /// - parameter remoteName:   A `String` representing the API name of the resource.
     /// - parameter context:      The `NSManagedObjectContext` we want to request the object from.
     /// - returns:                (Optional)The `NSManagedObject` or nil if no object for the given id is found.
-    public func getObject(from remoteID: String, remoteName: String, context: NSManagedObjectContext) throws -> NSManagedObject? {
+    public func managedObject(with remoteID: AnyHashable, remoteName: String, context: NSManagedObjectContext) throws -> NSManagedObject? {
 
         guard let serializer = entitiesByType[remoteName] else {
-            let message = String(format: "No serializer found for type '%@'", remoteName)
+            let message = String(format: "No serializer found for remote name '%@'", remoteName)
             throw EntitySerializerErrorCode.unknownType.error(message)
         }
 
         let fr: NSFetchRequest<NSManagedObject> = NSFetchRequest(entityName: serializer.name)
-        fr.predicate = NSPredicate(format: "id = %@", remoteID)
+        fr.predicate = NSPredicate(format: "id IN %@", [remoteID])
 
         do {
             let managedObjects = try context.fetch(fr)
 
             guard managedObjects.count <= 1 else {
-                throw NSError(domain: "Parsec.Parsec", code: 1, userInfo: [NSLocalizedDescriptionKey: "Only one or zero objects with this remoteId '\(remoteID)' must exists"])
+                throw NSError(domain: "Parsec.Parsec", code: 1, userInfo: [NSLocalizedDescriptionKey: "Multiple objects with remoteId '\(remoteID)' and type '\(remoteName)'"])
             }
 
             return managedObjects.first
         } catch {
-            throw EntitySerializerErrorCode.unknownType.error("No object found for entity '\(serializer.name)'")
+            throw error
         }
-
     }
 
     /// Returns an NSManagedObject array from Context given an APIObject array keeping the same order
     /// - parameter apiObjects:   A `[APIObject]` representing the list of  `APIObject` returned from the API.
     /// - parameter context:      The `NSManagedObjectContext` we want to request the objects from.
     /// - returns:                A `[NSManagedObject]`, empty if APIObjects is empty, order by apiObjects array id order.
-    public func objectsFrom(_ apiObjects: [APIObject], context: NSManagedObjectContext) throws -> [NSManagedObject] {
+    public func managedObjectsFrom(_ apiObjects: [APIObject], context: NSManagedObjectContext) throws -> [NSManagedObject] {
 
-        let apiObjectsIDs: [String] = try apiObjects.map {
-            guard let remoteId = $0.id as? String else {
-                throw NSError(domain: "Parsec.Parsec", code: 2, userInfo: [NSLocalizedDescriptionKey: "Returned APIObject without valid 'id'"])
+        let apiObjectsIDs: [AnyHashable] = try apiObjects.map {
+            guard let remoteId = $0.id else {
+                throw NSError(domain: "Parsec.Parsec", code: 2, userInfo: [NSLocalizedDescriptionKey: "APIObject (type '\($0.type)') without valid 'id'"])
             }
             return remoteId
         }
 
-        guard
-            let apiObject = apiObjects.first
-        else {
-                return [NSManagedObject]()
+        guard let apiObject = apiObjects.first else {
+            return [NSManagedObject]()
         }
 
-        guard
-            let serializer = entitiesByType[apiObject.type]
-        else {
+        guard let serializer = entitiesByType[apiObject.type] else {
             let message = String(format: "No serializer found for type '%@'", apiObject.type)
             throw EntitySerializerErrorCode.unknownType.error(message)
         }
@@ -419,37 +414,32 @@ public class Parsec {
         let fr: NSFetchRequest<NSManagedObject> = NSFetchRequest(entityName: serializer.name)
         fr.predicate = NSPredicate(format: "id IN %@", apiObjectsIDs)
 
-        do {
-            let managedObjects = try context.fetch(fr)
-            try context.obtainPermanentIDs(for: managedObjects)
+        let managedObjects = try context.fetch(fr)
+        try context.obtainPermanentIDs(for: managedObjects)
 
-            guard apiObjectsIDs.count == managedObjects.count else {
-                throw NSError(domain: "Parsec.Parsec", code: 3, userInfo: [NSLocalizedDescriptionKey: "APIObjects array and ManagedObjects retrieved must contains the same number of items"])
-            }
-
-            let result = try managedObjects.sorted { (leftObject, rightObject) -> Bool in
-                guard
-                    let leftID = leftObject.value(forKey: "id") as? String,
-                    let rightID = rightObject.value(forKey: "id") as? String
-                    else {
-                        throw NSError(domain: "Parsec.Parsec", code: 4, userInfo: [NSLocalizedDescriptionKey: "Stored ManagedObject without valid 'id' String property"])
-                }
-
-                guard
-                    let leftIndex = apiObjectsIDs.firstIndex(of: leftID),
-                    let rightIndex = apiObjectsIDs.firstIndex(of: rightID)
-                    else {
-                        throw NSError(domain: "Parsec.Parsec", code: 5, userInfo: [NSLocalizedDescriptionKey: "Index for ManagedObject 'id' not found in APIObject param array"])
-                }
-
-                return leftIndex < rightIndex
-            }
-
-            return result
-
-        } catch {
-            throw error
+        guard apiObjectsIDs.count == managedObjects.count else {
+            throw NSError(domain: "Parsec.Parsec", code: 3, userInfo: [NSLocalizedDescriptionKey: "APIObjects array and ManagedObjects retrieved must contains the same number of items"])
         }
+
+        let result = try managedObjects.sorted { (leftObject, rightObject) -> Bool in
+            guard
+                let leftID = leftObject.value(forKey: "id") as? AnyHashable,
+                let rightID = rightObject.value(forKey: "id") as? AnyHashable
+            else {
+                throw NSError(domain: "Parsec.Parsec", code: 4, userInfo: [NSLocalizedDescriptionKey: "Stored ManagedObject without valid 'id' String property"])
+            }
+
+            guard
+                let leftIndex = apiObjectsIDs.firstIndex(of: leftID),
+                let rightIndex = apiObjectsIDs.firstIndex(of: rightID)
+            else {
+                throw NSError(domain: "Parsec.Parsec", code: 5, userInfo: [NSLocalizedDescriptionKey: "Index for ManagedObject 'id' not found in APIObject param array"])
+            }
+
+            return leftIndex < rightIndex
+        }
+
+        return result
     }
 
     func deserialize(document: APIDocument) throws -> [ObjectData] {

--- a/Source/Parsec.swift
+++ b/Source/Parsec.swift
@@ -253,20 +253,6 @@ public struct APIRelationship {
     }
 }
 
-public enum LogLevel: Int {
-    case error
-    case warning
-    case info
-    case debug
-    case verbose
-}
-
-public protocol Logger {
-    func log(_ level: LogLevel, _ text: @autoclosure () -> String)
-    var logUnknown: Bool {get}
-    var logMissing: Bool {get}
-}
-
 /// *Parsec*
 public class Parsec {
 

--- a/Source/Parsec.swift
+++ b/Source/Parsec.swift
@@ -253,6 +253,20 @@ public struct APIRelationship {
     }
 }
 
+public enum LogLevel: Int {
+    case error
+    case warning
+    case info
+    case debug
+    case verbose
+}
+
+public protocol Logger {
+    func log(_ level: LogLevel, _ text: @autoclosure () -> String)
+    var logUnknown: Bool {get}
+    var logMissing: Bool {get}
+}
+
 /// *Parsec*
 public class Parsec {
 
@@ -262,6 +276,7 @@ public class Parsec {
     public let defaultDateSerializer: Serializer
     public let defaultDataSerializer: Serializer
     public let defaultIdNames: [String]
+    public var logger: Logger?
 
     private(set) var entitiesByName: [String: EntitySerializer]
     private(set) var entitiesByType: [String: EntitySerializer]


### PR DESCRIPTION
Added two new methods:

`getObject(from remoteID: String, remoteName: String, context: NSManagedObjectContext) throws -> NSManagedObject?`

to retrieve an NSManagedObject stored locally from it's RemoteID and API Resource Type

`objectsFrom(_ apiObjects: [APIObject], context: NSManagedObjectContext) throws -> [NSManagedObject]`

to retrieve an already stored array of NSManagedObject from an array of APIObject
