### PR TITLE
Support different entities send in apiObjects array param of func managedObjectsFrom...

### DIFF
--- a/Parsec.podspec
+++ b/Parsec.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = "Parsec"
-s.version          = "1.1.1"
+s.version          = "1.1.2"
 s.summary          = "Modular JSON API to Core Data parser and validator"
 s.description      = <<-DESC
 **Parsec** eases the task of getting `JSON API` documents into Core Data.
@@ -8,7 +8,7 @@ DESC
 s.homepage         = 'https://github.com/InQBarna/Parsec'
 s.license          = 'MIT'
 s.author           = { 'David Romacho' => 'david.romacho@inqbarna.com', 'Santiago Becerra' => 'santiago.becerra@inqbarna.com' }
-s.source           = { :git => "https://github.com/InQBarna/Parsec/Parsec.git", :tag => 'v1.1.1' }
+s.source           = { :git => "https://github.com/InQBarna/Parsec/Parsec.git", :tag => 'v1.1.2' }
 
 s.ios.deployment_target = '10.0'
 s.requires_arc = true


### PR DESCRIPTION
Refactor of `func managedObjectsFrom(_ apiObjects: [APIObject], context: NSManagedObjectContext) throws -> [NSManagedObject]` to handle different entities in the APIObjects array

Set version to 1.1.2 in podspec file